### PR TITLE
feat(frontend): add title and dark theme

### DIFF
--- a/frontend/src/app/components/results-list/results-list.component.css
+++ b/frontend/src/app/components/results-list/results-list.component.css
@@ -1,14 +1,26 @@
-table {
+ .title {
+  font-size: 2.5rem;
+  margin-bottom: 20px;
+ }
+
+ .filters input,
+ .filters button {
+  background-color: #333;
+  color: #fff;
+  border: 1px solid #555;
+ }
+
+ table {
   width: 100%;
   border-collapse: collapse;
-}
+ }
 
-th, td {
-  border: 1px solid #ddd;
+ th, td {
+  border: 1px solid #555;
   padding: 4px;
   text-align: center;
-}
+ }
 
-th {
-  background-color: #f2f2f2;
-}
+ th {
+  background-color: #222;
+ }

--- a/frontend/src/app/components/results-list/results-list.component.html
+++ b/frontend/src/app/components/results-list/results-list.component.html
@@ -1,3 +1,4 @@
+<h1 class="title">Resultados da Lotofácil</h1>
 <div class="filters">
   <label>
     <input type="checkbox" [(ngModel)]="useParImpar"> Par Ímpar

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,4 +1,6 @@
 body {
   font-family: Arial, Helvetica, sans-serif;
   margin: 20px;
+  background-color: #000;
+  color: #fff;
 }


### PR DESCRIPTION
## Summary
- add prominent title above filter inputs
- apply dark theme with black background and dark table/filter styles

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint` *(fails: Cannot find "lint" target for the specified project)*

------
https://chatgpt.com/codex/tasks/task_e_68b8eecff7588321bb4f0851b0c5b9fa