### PR TITLE
feat: add record counter and contest limit filter

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -15,6 +15,7 @@ def list_results():
     pares_param = request.args.get('pares', '')
     impares_param = request.args.get('impares', '')
     tres_por_linha = request.args.get('tresPorLinha', '').lower() in ('1', 'true', 'on')
+    concurso_limite = request.args.get('concursoLimite', type=int)
     pares = {int(p) for p in pares_param.split(',') if p}
     impares = {int(i) for i in impares_param.split(',') if i}
 
@@ -26,12 +27,15 @@ def list_results():
     rows = cur.fetchall()
     conn.close()
 
-    from filters import FiltroDezenasParesImpares, FiltroTresPorLinha
+    from filters import FiltroDezenasParesImpares, FiltroTresPorLinha, FiltroConcursoLimite
     filtro_paridade = FiltroDezenasParesImpares(pares, impares, ativo=bool(pares or impares))
     filtro_tres = FiltroTresPorLinha(ativo=tres_por_linha)
+    filtro_limite = FiltroConcursoLimite(concurso_limite, ativo=concurso_limite is not None)
     rows = filtro_paridade.apply(rows)
     rows = filtro_tres.apply(rows)
+    rows = filtro_limite.apply(rows)
 
+    total = len(rows)
     results = []
     for r in rows:
         dezenas = [r[f'n{i}'] for i in range(1, 16)]
@@ -42,7 +46,7 @@ def list_results():
             'ganhador': r['ganhador'],
         })
     results.sort(key=lambda x: x['concurso'], reverse=True)
-    return jsonify(results[:10])
+    return jsonify({'total': total, 'results': results[:10]})
 
 @app.after_request
 def add_cors_headers(response):

--- a/backend/filters.py
+++ b/backend/filters.py
@@ -34,3 +34,14 @@ class FiltroTresPorLinha:
             if all(l == 3 for l in linhas):
                 filtrados.append(r)
         return filtrados
+
+
+class FiltroConcursoLimite:
+    def __init__(self, limite=None, ativo=True):
+        self.limite = limite
+        self.ativo = ativo and limite is not None
+
+    def apply(self, rows):
+        if not self.ativo:
+            return list(rows)
+        return [r for r in rows if r['concurso'] <= self.limite]

--- a/frontend/src/app/components/results-list/results-list.component.css
+++ b/frontend/src/app/components/results-list/results-list.component.css
@@ -1,14 +1,30 @@
-table {
+ .title {
+  font-size: 2.5rem;
+  margin-bottom: 20px;
+ }
+
+ .filters input,
+ .filters button {
+  background-color: #333;
+  color: #fff;
+  border: 1px solid #555;
+ }
+
+ .record-count {
+  margin: 10px 0;
+ }
+
+ table {
   width: 100%;
   border-collapse: collapse;
-}
+ }
 
-th, td {
-  border: 1px solid #ddd;
+ th, td {
+  border: 1px solid #555;
   padding: 4px;
   text-align: center;
-}
+ }
 
-th {
-  background-color: #f2f2f2;
-}
+ th {
+  background-color: #222;
+ }

--- a/frontend/src/app/components/results-list/results-list.component.html
+++ b/frontend/src/app/components/results-list/results-list.component.html
@@ -1,3 +1,4 @@
+<h1 class="title">Resultados da Lotofácil</h1>
 <div class="filters">
   <label>
     <input type="checkbox" [(ngModel)]="useParImpar"> Par Ímpar
@@ -7,8 +8,11 @@
   <label>
     <input type="checkbox" [(ngModel)]="useTresPorLinha"> 3 por linha
   </label>
+  <input type="number" placeholder="Concurso Limite" [(ngModel)]="concursoLimite">
   <button (click)="loadResults()">Aplicar</button>
 </div>
+
+<p class="record-count">Total de registros: {{ totalRegistros }}</p>
 
 <h2>Últimos 10 resultados</h2>
 <table>

--- a/frontend/src/app/components/results-list/results-list.component.ts
+++ b/frontend/src/app/components/results-list/results-list.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { ResultsService, LotofacilResult } from '../../results.service';
+import { ResultsService, LotofacilResult, ResultsResponse } from '../../results.service';
 
 @Component({
   selector: 'app-results-list',
@@ -12,6 +12,8 @@ export class ResultsListComponent implements OnInit {
   useTresPorLinha = false;
   pares = '';
   impares = '';
+  concursoLimite = '';
+  totalRegistros = 0;
 
   constructor(private resultsService: ResultsService) {}
 
@@ -30,8 +32,13 @@ export class ResultsListComponent implements OnInit {
       .filter(v => !isNaN(v));
     const pares = this.useParImpar ? paresVals : [];
     const impares = this.useParImpar ? imparesVals : [];
+    const limiteVal = parseInt(this.concursoLimite, 10);
+    const limite = isNaN(limiteVal) ? undefined : limiteVal;
     this.resultsService
-      .getLastResults(pares, impares, this.useTresPorLinha)
-      .subscribe(r => (this.results = r));
+      .getLastResults(pares, impares, this.useTresPorLinha, limite)
+      .subscribe((r: ResultsResponse) => {
+        this.results = r.results;
+        this.totalRegistros = r.total;
+      });
   }
 }

--- a/frontend/src/app/results.service.ts
+++ b/frontend/src/app/results.service.ts
@@ -9,6 +9,11 @@ export interface LotofacilResult {
   ganhador: number;
 }
 
+export interface ResultsResponse {
+  total: number;
+  results: LotofacilResult[];
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -20,8 +25,9 @@ export class ResultsService {
   getLastResults(
     pares: number[] = [],
     impares: number[] = [],
-    tresPorLinha = false
-  ): Observable<LotofacilResult[]> {
+    tresPorLinha = false,
+    concursoLimite?: number
+  ): Observable<ResultsResponse> {
     let params = new HttpParams();
     if (pares.length) {
       params = params.set('pares', pares.join(','));
@@ -32,6 +38,9 @@ export class ResultsService {
     if (tresPorLinha) {
       params = params.set('tresPorLinha', 'true');
     }
-    return this.http.get<LotofacilResult[]>(this.API_URL, { params });
+    if (concursoLimite !== undefined) {
+      params = params.set('concursoLimite', concursoLimite.toString());
+    }
+    return this.http.get<ResultsResponse>(this.API_URL, { params });
   }
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,4 +1,6 @@
 body {
   font-family: Arial, Helvetica, sans-serif;
   margin: 20px;
+  background-color: #000;
+  color: #fff;
 }


### PR DESCRIPTION
## Summary
- allow filtering results by a maximum contest number
- expose total number of filtered results and display it in the UI

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*
- `npm run lint` *(fails: Cannot find "lint" target for the specified project)*
- `pytest` *(passes: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68b8eecff7588321bb4f0851b0c5b9fa