### PR TITLE
Fix query parameter parsing for results API

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -24,12 +24,12 @@ def list_results():
                         continue
         return nums
 
-    pares = _parse_int_list(request.args.getlist('pares'))
-    impares = _parse_int_list(request.args.getlist('impares'))
+    pares_param = request.args.get('pares', '')
+    impares_param = request.args.get('impares', '')
+    pares = _parse_int_list(request.args.getlist('pares') or [pares_param])
+    impares = _parse_int_list(request.args.getlist('impares') or [impares_param])
     tres_por_linha = request.args.get('tresPorLinha', '').lower() in ('1', 'true', 'on')
     concurso_limite = request.args.get('concursoLimite', type=int)
-    pares = {int(p) for p in pares_param.split(',') if p}
-    impares = {int(i) for i in impares_param.split(',') if i}
 
     conn = get_connection()
     cur = conn.execute(


### PR DESCRIPTION
## Summary
- Fix parsing for `pares` and `impares` query parameters in results API

## Testing
- `pytest`
- `curl -s http://127.0.0.1:5000/api/results` *(fails: no such table: results)*

------
https://chatgpt.com/codex/tasks/task_e_68b8fd6412208321bf76add619fc15b9