### PR TITLE
feat: switch results source

### DIFF
--- a/frontend/src/app/components/results-list/results-list.component.html
+++ b/frontend/src/app/components/results-list/results-list.component.html
@@ -6,7 +6,10 @@
   <input type="text" placeholder="Pares (ex: 6,7,8)" [(ngModel)]="pares" [disabled]="!useParImpar">
   <input type="text" placeholder="Ímpares (ex: 7,8)" [(ngModel)]="impares" [disabled]="!useParImpar">
   <label>
-    <input type="checkbox" [(ngModel)]="useTresPorLinha"> 3 por linha
+    <input type="radio" name="fonte" [(ngModel)]="useTresPorLinha" [value]="false"> Últimos resultados
+  </label>
+  <label>
+    <input type="radio" name="fonte" [(ngModel)]="useTresPorLinha" [value]="true"> 3 por linha
   </label>
   <input type="number" placeholder="Concurso Limite" [(ngModel)]="concursoLimite">
   <button (click)="loadResults()">Aplicar</button>


### PR DESCRIPTION
## Summary
- allow choosing between last results or 3-per-line bets
- serve 3-per-line bets from CSV via API

## Testing
- `npm test -- --no-watch` (fails: Unknown argument: watch)
- `python -m py_compile backend/app.py backend/filters.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba440c2cd48321a9ce9afad79d338f