### PR TITLE
feat: add page for 3-per-line bets

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,5 +1,6 @@
 from flask import Flask, jsonify, request
 import sqlite3
+import csv
 from pathlib import Path
 
 app = Flask(__name__)
@@ -58,6 +59,57 @@ def list_results():
             'ganhador': r['ganhador'],
         })
     results.sort(key=lambda x: x['concurso'], reverse=True)
+    return jsonify({'total': total, 'results': results[:10]})
+
+
+@app.route('/api/apostas')
+def list_apostas():
+    def _parse_int_list(values):
+        nums = set()
+        for v in values:
+            for part in v.replace(';', ',').split(','):
+                part = part.strip()
+                if part:
+                    try:
+                        nums.add(int(part))
+                    except ValueError:
+                        continue
+        return nums
+
+    pares_param = request.args.get('pares', '')
+    impares_param = request.args.get('impares', '')
+    pares = _parse_int_list(request.args.getlist('pares') or [pares_param])
+    impares = _parse_int_list(request.args.getlist('impares') or [impares_param])
+    concurso_limite = request.args.get('concursoLimite', type=int)
+
+    csv_path = Path(__file__).resolve().parent.parent / 'todasTresPorLinha.csv'
+    with csv_path.open(newline='') as f:
+        reader = csv.DictReader(f)
+        rows = []
+        for idx, row in enumerate(reader, start=1):
+            data_row = {f'n{i}': int(row[f'B{i}']) for i in range(1, 16)}
+            data_row['concurso'] = idx
+            data_row['data'] = ''
+            data_row['ganhador'] = 0
+            rows.append(data_row)
+
+    from filters import FiltroDezenasParesImpares, FiltroConcursoLimite
+    filtro_paridade = FiltroDezenasParesImpares(pares, impares, ativo=bool(pares or impares))
+    filtro_limite = FiltroConcursoLimite(concurso_limite, ativo=concurso_limite is not None)
+    rows = filtro_paridade.apply(rows)
+    rows = filtro_limite.apply(rows)
+
+    total = len(rows)
+    results = []
+    for r in rows:
+        dezenas = [r[f'n{i}'] for i in range(1, 16)]
+        results.append({
+            'concurso': r['concurso'],
+            'data': r['data'],
+            'dezenas': dezenas,
+            'ganhador': r['ganhador'],
+        })
+    results.sort(key=lambda x: x['concurso'])
     return jsonify({'total': total, 'results': results[:10]})
 
 @app.after_request

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -1,10 +1,12 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { ResultsListComponent } from './components/results-list/results-list.component';
+import { TresPorLinhaListComponent } from './components/tres-por-linha-list/tres-por-linha-list.component';
 
 const routes: Routes = [
   { path: '', redirectTo: '/results', pathMatch: 'full' },
-  { path: 'results', component: ResultsListComponent }
+  { path: 'results', component: ResultsListComponent },
+  { path: 'tres-por-linha', component: TresPorLinhaListComponent }
 ];
 
 @NgModule({

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -5,13 +5,15 @@ import { FormsModule } from '@angular/forms';
 
 import { AppComponent } from './app.component';
 import { ResultsListComponent } from './components/results-list/results-list.component';
+import { TresPorLinhaListComponent } from './components/tres-por-linha-list/tres-por-linha-list.component';
 import { AppRoutingModule } from './app-routing.module';
 
 
 @NgModule({
   declarations: [
     AppComponent,
-    ResultsListComponent
+    ResultsListComponent,
+    TresPorLinhaListComponent
   ],
   imports: [
     BrowserModule,

--- a/frontend/src/app/components/tres-por-linha-list/tres-por-linha-list.component.css
+++ b/frontend/src/app/components/tres-por-linha-list/tres-por-linha-list.component.css
@@ -1,0 +1,30 @@
+.title {
+  font-size: 2.5rem;
+  margin-bottom: 20px;
+}
+
+.filters input,
+.filters button {
+  background-color: #333;
+  color: #fff;
+  border: 1px solid #555;
+}
+
+.record-count {
+  margin: 10px 0;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th, td {
+  border: 1px solid #555;
+  padding: 4px;
+  text-align: center;
+}
+
+th {
+  background-color: #222;
+}

--- a/frontend/src/app/components/tres-por-linha-list/tres-por-linha-list.component.html
+++ b/frontend/src/app/components/tres-por-linha-list/tres-por-linha-list.component.html
@@ -1,0 +1,28 @@
+<h1 class="title">Apostas 3 por linha</h1>
+<div class="filters">
+  <label>
+    <input type="checkbox" [(ngModel)]="useParImpar"> Par Ímpar
+  </label>
+  <input type="text" placeholder="Pares (ex: 6,7,8)" [(ngModel)]="pares" [disabled]="!useParImpar">
+  <input type="text" placeholder="Ímpares (ex: 7,8)" [(ngModel)]="impares" [disabled]="!useParImpar">
+  <input type="number" placeholder="Concurso Limite" [(ngModel)]="concursoLimite">
+  <button (click)="loadResults()">Aplicar</button>
+</div>
+
+<p class="record-count">Total de registros: {{ totalRegistros }}</p>
+
+<h2>Primeiros 10 registros</h2>
+<table>
+  <thead>
+    <tr>
+      <th>Concurso</th>
+      <th>Dezenas</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr *ngFor="let r of results">
+      <td>{{ r.concurso }}</td>
+      <td>{{ r.dezenas.join(', ') }}</td>
+    </tr>
+  </tbody>
+</table>

--- a/frontend/src/app/components/tres-por-linha-list/tres-por-linha-list.component.ts
+++ b/frontend/src/app/components/tres-por-linha-list/tres-por-linha-list.component.ts
@@ -1,0 +1,45 @@
+import { Component, OnInit } from '@angular/core';
+import { ResultsService, LotofacilResult, ResultsResponse } from '../../results.service';
+
+@Component({
+  selector: 'app-tres-por-linha-list',
+  templateUrl: './tres-por-linha-list.component.html',
+  styleUrls: ['./tres-por-linha-list.component.css']
+})
+export class TresPorLinhaListComponent implements OnInit {
+  results: LotofacilResult[] = [];
+  useParImpar = false;
+  pares = '';
+  impares = '';
+  concursoLimite = '';
+  totalRegistros = 0;
+
+  constructor(private resultsService: ResultsService) {}
+
+  ngOnInit(): void {
+    this.loadResults();
+  }
+
+  loadResults(): void {
+    const paresVals = this.pares
+      .replace(/;/g, ',')
+      .split(',')
+      .map(v => parseInt(v.trim(), 10))
+      .filter(v => !isNaN(v));
+    const imparesVals = this.impares
+      .replace(/;/g, ',')
+      .split(',')
+      .map(v => parseInt(v.trim(), 10))
+      .filter(v => !isNaN(v));
+    const pares = this.useParImpar ? paresVals : [];
+    const impares = this.useParImpar ? imparesVals : [];
+    const limiteVal = parseInt(this.concursoLimite, 10);
+    const limite = isNaN(limiteVal) ? undefined : limiteVal;
+    this.resultsService
+      .getTresPorLinhaBets(pares, impares, limite)
+      .subscribe((r: ResultsResponse) => {
+        this.results = r.results;
+        this.totalRegistros = r.total;
+      });
+  }
+}

--- a/frontend/src/app/results.service.ts
+++ b/frontend/src/app/results.service.ts
@@ -19,6 +19,7 @@ export interface ResultsResponse {
 })
 export class ResultsService {
   private readonly API_URL = 'http://localhost:5000/api/results';
+  private readonly BETS_URL = 'http://localhost:5000/api/apostas';
 
   constructor(private http: HttpClient) {}
 
@@ -46,5 +47,27 @@ export class ResultsService {
       params = params.set('concursoLimite', concursoLimite.toString());
     }
     return this.http.get<ResultsResponse>(this.API_URL, { params });
+  }
+
+  getTresPorLinhaBets(
+    pares: number[] = [],
+    impares: number[] = [],
+    concursoLimite?: number
+  ): Observable<ResultsResponse> {
+    let params = new HttpParams();
+    if (pares.length) {
+      pares.forEach(p => {
+        params = params.append('pares', p.toString());
+      });
+    }
+    if (impares.length) {
+      impares.forEach(i => {
+        params = params.append('impares', i.toString());
+      });
+    }
+    if (concursoLimite !== undefined) {
+      params = params.set('concursoLimite', concursoLimite.toString());
+    }
+    return this.http.get<ResultsResponse>(this.BETS_URL, { params });
   }
 }


### PR DESCRIPTION
## Summary
- revert previous results toggle and restore original results page
- serve 3-per-line bets from `todasTresPorLinha.csv` via new API endpoint
- add Angular route and component to browse 3-per-line bets

## Testing
- `python -m py_compile backend/app.py backend/filters.py`
- `npm test --watch=false --browsers=ChromeHeadless` (fails: Cannot determine project or target for command)


------
https://chatgpt.com/codex/tasks/task_e_68ba440c2cd48321a9ce9afad79d338f