### PR TITLE
Remove tres por linha option

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -29,32 +29,19 @@ def list_results():
     impares_param = request.args.get('impares', '')
     pares = _parse_int_list(request.args.getlist('pares') or [pares_param])
     impares = _parse_int_list(request.args.getlist('impares') or [impares_param])
-    tres_por_linha = request.args.get('tresPorLinha', '').lower() in ('1', 'true', 'on')
     concurso_limite = request.args.get('concursoLimite', type=int)
 
     from filters import FiltroDezenasParesImpares, FiltroConcursoLimite
     filtro_paridade = FiltroDezenasParesImpares(pares, impares, ativo=bool(pares or impares))
     filtro_limite = FiltroConcursoLimite(concurso_limite, ativo=concurso_limite is not None)
 
-    if tres_por_linha:
-        csv_path = Path(__file__).resolve().parent.parent / 'todasTresPorLinha.csv'
-        with csv_path.open(newline='') as f:
-            reader = csv.DictReader(f)
-            rows = []
-            for idx, row in enumerate(reader, start=1):
-                data_row = {f'n{i}': int(row[f'B{i}']) for i in range(1, 16)}
-                data_row['concurso'] = idx
-                data_row['data'] = ''
-                data_row['ganhador'] = 0
-                rows.append(data_row)
-    else:
-        conn = get_connection()
-        cur = conn.execute(
-            'SELECT concurso, data, n1, n2, n3, n4, n5, n6, n7, n8, n9, n10, n11, n12, n13, n14, n15, ganhador '
-            'FROM results'
-        )
-        rows = cur.fetchall()
-        conn.close()
+    conn = get_connection()
+    cur = conn.execute(
+        'SELECT concurso, data, n1, n2, n3, n4, n5, n6, n7, n8, n9, n10, n11, n12, n13, n14, n15, ganhador '
+        'FROM results'
+    )
+    rows = cur.fetchall()
+    conn.close()
 
     rows = filtro_paridade.apply(rows)
     rows = filtro_limite.apply(rows)

--- a/frontend/src/app/components/results-list/results-list.component.html
+++ b/frontend/src/app/components/results-list/results-list.component.html
@@ -5,12 +5,6 @@
   </label>
   <input type="text" placeholder="Pares (ex: 6,7,8)" [(ngModel)]="pares" [disabled]="!useParImpar">
   <input type="text" placeholder="Ímpares (ex: 7,8)" [(ngModel)]="impares" [disabled]="!useParImpar">
-  <label>
-    <input type="radio" name="fonte" [(ngModel)]="useTresPorLinha" [value]="false"> Últimos resultados
-  </label>
-  <label>
-    <input type="radio" name="fonte" [(ngModel)]="useTresPorLinha" [value]="true"> 3 por linha
-  </label>
   <input type="number" placeholder="Concurso Limite" [(ngModel)]="concursoLimite">
   <button (click)="loadResults()">Aplicar</button>
 </div>

--- a/frontend/src/app/components/results-list/results-list.component.ts
+++ b/frontend/src/app/components/results-list/results-list.component.ts
@@ -9,7 +9,6 @@ import { ResultsService, LotofacilResult, ResultsResponse } from '../../results.
 export class ResultsListComponent implements OnInit {
   results: LotofacilResult[] = [];
   useParImpar = false;
-  useTresPorLinha = false;
   pares = '';
   impares = '';
   concursoLimite = '';
@@ -37,7 +36,7 @@ export class ResultsListComponent implements OnInit {
     const limiteVal = parseInt(this.concursoLimite, 10);
     const limite = isNaN(limiteVal) ? undefined : limiteVal;
     this.resultsService
-      .getLastResults(pares, impares, this.useTresPorLinha, limite)
+      .getLastResults(pares, impares, limite)
       .subscribe((r: ResultsResponse) => {
         this.results = r.results;
         this.totalRegistros = r.total;

--- a/frontend/src/app/results.service.ts
+++ b/frontend/src/app/results.service.ts
@@ -26,7 +26,6 @@ export class ResultsService {
   getLastResults(
     pares: number[] = [],
     impares: number[] = [],
-    tresPorLinha = false,
     concursoLimite?: number
   ): Observable<ResultsResponse> {
     let params = new HttpParams();
@@ -39,9 +38,6 @@ export class ResultsService {
       impares.forEach(i => {
         params = params.append('impares', i.toString());
       });
-    }
-    if (tresPorLinha) {
-      params = params.set('tresPorLinha', 'true');
     }
     if (concursoLimite !== undefined) {
       params = params.set('concursoLimite', concursoLimite.toString());


### PR DESCRIPTION
## Summary
- drop UI toggle and service parameter for `tresPorLinha`
- simplify backend results endpoint to always query database

## Testing
- `python -m py_compile backend/app.py backend/filters.py`
- `npm test -- --no-watch` *(fails: Workspace extension with invalid name (defaultProject) found. Error: Unknown argument: watch)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4b9fa2d483219867e12e355fd1e0